### PR TITLE
Introduce rate limiting infrastructure with Symfony Rate Limiter package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
         "symfony/monolog-bundle": "^3.10",
         "symfony/property-access": "^7.3",
         "symfony/property-info": "^7.3",
+        "symfony/rate-limiter": "^7.3",
         "symfony/runtime": "^7.3",
         "symfony/serializer": "^7.3",
         "symfony/twig-bundle": "^7.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b355a39ed5d5058da2d3e2f513772d6f",
+    "content-hash": "e2f7c65eab9e82251ad429bcc997fd09",
     "packages": [
         {
             "name": "doctrine/collections",
@@ -5940,6 +5940,80 @@
                 }
             ],
             "time": "2024-09-26T08:57:56+00:00"
+        },
+        {
+            "name": "symfony/rate-limiter",
+            "version": "v7.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/rate-limiter.git",
+                "reference": "7e855541d302ba752f86fb0e97932e7969fe9c04"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/rate-limiter/zipball/7e855541d302ba752f86fb0e97932e7969fe9c04",
+                "reference": "7e855541d302ba752f86fb0e97932e7969fe9c04",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/options-resolver": "^7.3"
+            },
+            "require-dev": {
+                "psr/cache": "^1.0|^2.0|^3.0",
+                "symfony/lock": "^6.4|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\RateLimiter\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Wouter de Jong",
+                    "email": "wouter@wouterj.nl"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides a Token Bucket implementation to rate limit input and output in your application",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "limiter",
+                "rate-limiter"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/rate-limiter/tree/v7.3.2"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-07-07T08:17:57+00:00"
         },
         {
             "name": "symfony/routing",

--- a/config/packages/rate_limiter.php
+++ b/config/packages/rate_limiter.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Shared\RateLimiter\Enum\Type;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $containerConfigurator->parameters()->set('rate_limiter.enabled', true);
+
+    $containerConfigurator->extension('framework', [
+        'rate_limiter' => [
+            Type::REGISTER->value => [
+                'policy' => 'fixed_window',
+                'limit' => 5,
+                'interval' => '60 minutes',
+            ],
+            Type::LOGIN->value => [
+                'policy' => 'fixed_window',
+                'limit' => 3,
+                'interval' => '10 minutes',
+            ],
+            Type::PASSWORD_RESET_REQUEST->value => [
+                'policy' => 'fixed_window',
+                'limit' => 3,
+                'interval' => '60 minutes',
+            ],
+            Type::PASSWORD_RESET_CONFIRM->value => [
+                'policy' => 'fixed_window',
+                'limit' => 3,
+                'interval' => '60 minutes',
+            ],
+            Type::PASSWORD_RESET_TOKEN_CHECK->value => [
+                'policy' => 'fixed_window',
+                'limit' => 3,
+                'interval' => '60 minutes',
+            ],
+        ],
+    ]);
+};

--- a/src/Auth/Action/RegisterAction.php
+++ b/src/Auth/Action/RegisterAction.php
@@ -6,6 +6,8 @@ namespace App\Auth\Action;
 
 use App\Auth\Model\RegisterRequest;
 use App\Auth\RegisterUserAction;
+use App\Shared\RateLimiter\Attribute\RateLimiting;
+use App\Shared\RateLimiter\Enum\Type;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -13,6 +15,7 @@ use Symfony\Component\HttpKernel\Attribute\AsController;
 use Symfony\Component\HttpKernel\Attribute\MapRequestPayload;
 use Symfony\Component\Routing\Attribute\Route;
 
+#[RateLimiting(Type::REGISTER->value)]
 #[Route(
     path: '/auth/register',
     name: 'auth_register',

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -4,10 +4,21 @@ declare(strict_types=1);
 
 namespace App;
 
+use App\Shared\RateLimiter\CompilerPass\RateLimitingPass;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Kernel as BaseKernel;
 
 class Kernel extends BaseKernel
 {
     use MicroKernelTrait;
+
+    #[\Override]
+    public function buildContainer(): ContainerBuilder
+    {
+        $containerBuilder = parent::buildContainer();
+        $containerBuilder->addCompilerPass(new RateLimitingPass());
+
+        return $containerBuilder;
+    }
 }

--- a/src/Shared/EventListener/ExceptionListener.php
+++ b/src/Shared/EventListener/ExceptionListener.php
@@ -15,6 +15,7 @@ use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\RateLimiter\Exception\RateLimitExceededException;
 use Symfony\Component\Uid\Uuid;
 use Symfony\Component\Validator\Exception\ValidationFailedException;
 
@@ -78,6 +79,7 @@ final readonly class ExceptionListener
             || $exception instanceof NotFoundHttpException
             || $exception instanceof MethodNotAllowedHttpException
             || $exception instanceof InvalidArgumentException
+            || $exception instanceof RateLimitExceededException
             || $exception->getPrevious() instanceof ValidationFailedException
         ) {
             return false;

--- a/src/Shared/RateLimiter/Attribute/RateLimiting.php
+++ b/src/Shared/RateLimiter/Attribute/RateLimiting.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\RateLimiter\Attribute;
+
+#[\Attribute(\Attribute::TARGET_CLASS)]
+final readonly class RateLimiting
+{
+    public function __construct(
+        public string $configuration,
+    ) {
+    }
+}

--- a/src/Shared/RateLimiter/CompilerPass/RateLimitingPass.php
+++ b/src/Shared/RateLimiter/CompilerPass/RateLimitingPass.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\RateLimiter\CompilerPass;
+
+use App\Shared\RateLimiter\Attribute\RateLimiting;
+use App\Shared\RateLimiter\EventListener\ApplyRateLimitingListener;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+final readonly class RateLimitingPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        $taggedServices = $container->findTaggedServiceIds('controller.service_arguments');
+
+        /** @var Definition[] $serviceDefinitions */
+        $serviceDefinitions = array_map(fn (string $id) => $container->getDefinition($id), array_keys($taggedServices));
+
+        $rateLimiterClassMap = [];
+
+        foreach ($serviceDefinitions as $serviceDefinition) {
+            $controllerClass = $serviceDefinition->getClass();
+            $reflectionClass = $container->getReflectionClass($controllerClass);
+
+            $attributes = $reflectionClass?->getAttributes(RateLimiting::class) ?? [];
+
+            if (\count($attributes) > 0) {
+                [$attribute] = $attributes;
+
+                $serviceKey = sprintf('limiter.%s', $attribute->newInstance()->configuration);
+                $rateLimiterClassMap[$reflectionClass->getName()] = $container->getDefinition($serviceKey);
+            }
+        }
+
+        $container->getDefinition(ApplyRateLimitingListener::class)->setArgument('$rateLimiterClassMap', $rateLimiterClassMap);
+    }
+}

--- a/src/Shared/RateLimiter/Enum/Type.php
+++ b/src/Shared/RateLimiter/Enum/Type.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\RateLimiter\Enum;
+
+enum Type: string
+{
+    case REGISTER = 'register';
+    case LOGIN = 'login';
+    case PASSWORD_RESET_REQUEST = 'password_reset_request';
+    case PASSWORD_RESET_CONFIRM = 'password_reset_confirm';
+    case PASSWORD_RESET_TOKEN_CHECK = 'password_reset_token_check';
+}

--- a/src/Shared/RateLimiter/EventListener/ApplyRateLimitingListener.php
+++ b/src/Shared/RateLimiter/EventListener/ApplyRateLimitingListener.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\RateLimiter\EventListener;
+
+use App\Auth\Enum\Role;
+use App\User\Entity\User;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\KernelEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Role\RoleHierarchyInterface;
+
+#[AsEventListener(event: KernelEvents::CONTROLLER)]
+final readonly class ApplyRateLimitingListener
+{
+    public function __construct(
+        private TokenStorageInterface $tokenStorage,
+        #[Autowire('%rate_limiter.enabled%')]
+        private bool $isRateLimiterEnabled,
+        /** @var RateLimiterFactory[] */
+        private array $rateLimiterClassMap,
+        private RoleHierarchyInterface $roleHierarchy,
+    ) {
+    }
+
+    public function __invoke(KernelEvent $event): void
+    {
+        if (!$this->isRateLimiterEnabled || !$event->isMainRequest()) {
+            return;
+        }
+
+        $request = $event->getRequest();
+        /** @var string $controllerClass */
+        $controllerClass = $request->attributes->get('_controller');
+
+        $rateLimiter = $this->rateLimiterClassMap[$controllerClass] ?? null;
+
+        if (null === $rateLimiter) {
+            return;
+        }
+
+        $token = $this->tokenStorage->getToken();
+        if ($token instanceof TokenInterface && in_array(Role::ADMIN->value, $this->roleHierarchy->getReachableRoleNames($token->getRoleNames()))) {
+            return;
+        }
+
+        /** @var string $clientIp */
+        $clientIp = $request->getClientIp();
+
+        $this->ensureRateLimiting($request, $rateLimiter, $clientIp);
+    }
+
+    private function ensureRateLimiting(Request $request, RateLimiterFactory $rateLimiter, string $clientIp): void
+    {
+        $limit = $rateLimiter->create(sprintf('rate_limit_ip_%s', $clientIp))->consume();
+        $request->attributes->set('rate_limit', $limit);
+        $limit->ensureAccepted();
+
+        $user = $this->tokenStorage->getToken()?->getUser();
+
+        if ($user instanceof User) {
+            $limit = $rateLimiter->create(sprintf('rate_limit_user_%s', $user->getId()))->consume();
+            $request->attributes->set('rate_limit', $limit);
+            $limit->ensureAccepted();
+        }
+    }
+}

--- a/src/Shared/RateLimiter/EventListener/RateLimitExceededExceptionListener.php
+++ b/src/Shared/RateLimiter/EventListener/RateLimitExceededExceptionListener.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\RateLimiter\EventListener;
+
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\RateLimiter\Exception\RateLimitExceededException;
+
+#[AsEventListener(event: KernelEvents::EXCEPTION)]
+final readonly class RateLimitExceededExceptionListener
+{
+    public function __invoke(ExceptionEvent $event): void
+    {
+        $exception = $event->getThrowable();
+
+        if (!$this->isSupported($exception)) {
+            return;
+        }
+
+        $response = new Response();
+        $response->setStatusCode(Response::HTTP_TOO_MANY_REQUESTS);
+
+        $event->setResponse($response);
+    }
+
+    private function isSupported(\Throwable $exception): bool
+    {
+        if ($exception instanceof RateLimitExceededException) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Shared/RateLimiter/EventListener/RateLimitingResponseHeadersListener.php
+++ b/src/Shared/RateLimiter/EventListener/RateLimitingResponseHeadersListener.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\RateLimiter\EventListener;
+
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\RateLimiter\RateLimit;
+
+#[AsEventListener(KernelEvents::RESPONSE)]
+final readonly class RateLimitingResponseHeadersListener
+{
+    public function __invoke(ResponseEvent $event): void
+    {
+        if (($rateLimit = $event->getRequest()->attributes->get('rate_limit')) instanceof RateLimit) {
+            $event->getResponse()->headers->add([
+                'RateLimit-Remaining' => $rateLimit->getRemainingTokens(),
+                'RateLimit-Reset' => time() - $rateLimit->getRetryAfter()->getTimestamp(),
+                'RateLimit-Limit' => $rateLimit->getLimit(),
+            ]);
+        }
+    }
+}

--- a/tests/Auth/Serializer/AuthSerializationGroupNormalizerTest.php
+++ b/tests/Auth/Serializer/AuthSerializationGroupNormalizerTest.php
@@ -9,7 +9,9 @@ use App\User\Entity\User;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
-use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Role\RoleHierarchyInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 final class AuthSerializationGroupNormalizerTest extends TestCase
@@ -19,39 +21,44 @@ final class AuthSerializationGroupNormalizerTest extends TestCase
     /** @var ObjectProphecy<NormalizerInterface> */
     private ObjectProphecy $normalizer;
 
-    /** @var ObjectProphecy<Security> */
-    private ObjectProphecy $security;
+    /** @var ObjectProphecy<TokenStorageInterface> */
+    private ObjectProphecy $tokenStorage;
 
     public function setUp(): void
     {
         $this->normalizer = $this->prophesize(NormalizerInterface::class);
-        $this->security = $this->prophesize(Security::class);
+        $this->tokenStorage = $this->prophesize(TokenStorageInterface::class);
     }
 
     public function testItNormalizesForUser(): void
     {
         $user = new User();
         $user->setRoles(['ROLE_USER', 'ROLE_TEST']);
-
-        $this->security->getUser()->willReturn($user);
+        $token = $this->prophesize(TokenInterface::class);
+        $token->getUser()->willReturn($user);
+        $token->getRoleNames()->willReturn(['ROLE_USER', 'ROLE_TEST']);
+        $this->tokenStorage->getToken()->willReturn($token->reveal());
+        $roleHierarchy = $this->prophesize(RoleHierarchyInterface::class);
+        $roleHierarchy->getReachableRoleNames($user->getRoles())->willReturn(['ROLE_USER', 'ROLE_TEST']);
 
         $data = ['key' => 'value'];
         $context = ['groups' => ['test:get']];
 
         $this->normalizer->normalize($data, null, ['groups' => ['test:get', 'test:get:user', 'test:get:test']])->willReturn([])->shouldBeCalled();
 
-        new AuthSerializationGroupNormalizer($this->normalizer->reveal(), $this->security->reveal())->normalize($data, null, $context);
+        new AuthSerializationGroupNormalizer($this->normalizer->reveal(), $this->tokenStorage->reveal(), $roleHierarchy->reveal())->normalize($data, null, $context);
     }
 
     public function testItNormalizesForGuest(): void
     {
-        $this->security->getUser()->willReturn(null);
+        $this->tokenStorage->getToken()->willReturn(null);
+        $roleHierarchy = $this->prophesize(RoleHierarchyInterface::class);
 
         $data = ['key' => 'value'];
         $context = ['groups' => ['test:get']];
 
         $this->normalizer->normalize($data, null, ['groups' => ['test:get', 'test:get:guest']])->willReturn([])->shouldBeCalled();
 
-        new AuthSerializationGroupNormalizer($this->normalizer->reveal(), $this->security->reveal())->normalize($data, null, $context);
+        new AuthSerializationGroupNormalizer($this->normalizer->reveal(), $this->tokenStorage->reveal(), $roleHierarchy->reveal())->normalize($data, null, $context);
     }
 }

--- a/tests/Shared/RateLimiter/EventListener/RateLimitExceededExceptionListenerTest.php
+++ b/tests/Shared/RateLimiter/EventListener/RateLimitExceededExceptionListenerTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Shared\RateLimiter\EventListener;
+
+use App\Shared\RateLimiter\EventListener\RateLimitExceededExceptionListener;
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\RateLimiter\Exception\RateLimitExceededException;
+
+final class RateLimitExceededExceptionListenerTest extends TestCase
+{
+    use ProphecyTrait;
+
+    public function testItCatchRateLimitExceededException(): void
+    {
+        $exception = $this->prophesize(RateLimitExceededException::class);
+
+        $event = new ExceptionEvent($this->prophesize(HttpKernelInterface::class)->reveal(), $this->prophesize(Request::class)->reveal(), 1, $exception->reveal());
+
+        new RateLimitExceededExceptionListener()->__invoke($event);
+
+        $response = $event->getResponse();
+
+        self::assertSame(Response::HTTP_TOO_MANY_REQUESTS, $response->getStatusCode());
+    }
+}

--- a/tests/Shared/RateLimiter/EventListener/RateLimitingResponseHeadersListenerTest.php
+++ b/tests/Shared/RateLimiter/EventListener/RateLimitingResponseHeadersListenerTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Shared\RateLimiter\EventListener;
+
+use App\Shared\RateLimiter\EventListener\RateLimitingResponseHeadersListener;
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Symfony\Component\HttpFoundation\ParameterBag;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\RateLimiter\RateLimit;
+
+final class RateLimitingResponseHeadersListenerTest extends TestCase
+{
+    use ProphecyTrait;
+
+    public function testItAddsRateLimitHeaders(): void
+    {
+        $rateLimit = $this->prophesize(RateLimit::class);
+        $rateLimit->getRemainingTokens()->willReturn(10);
+        $rateLimit->getRetryAfter()->willReturn(new \DateTimeImmutable());
+        $rateLimit->getLimit()->willReturn(15);
+
+        $parameters = $this->prophesize(ParameterBag::class);
+        $parameters->get('rate_limit')->willReturn(
+            $rateLimit->reveal()
+        );
+
+        $request = $this->prophesize(Request::class);
+        $request->attributes = $parameters;
+        $kernel = $this->prophesize(HttpKernelInterface::class);
+        $event = new ResponseEvent($kernel->reveal(), $request->reveal(), 1, new Response());
+
+        new RateLimitingResponseHeadersListener()->__invoke($event);
+
+        $response = $event->getResponse();
+
+        $headerKeys = array_keys($response->headers->all());
+
+        self::assertContains('ratelimit-remaining', $headerKeys);
+        self::assertContains('ratelimit-reset', $headerKeys);
+        self::assertContains('ratelimit-limit', $headerKeys);
+        self::assertSame('10', $response->headers->get('ratelimit-remaining'));
+        self::assertSame('0', $response->headers->get('ratelimit-reset'));
+        self::assertSame('15', $response->headers->get('ratelimit-limit'));
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added rate limiting for registration, login, and password reset actions with per-IP and per-user limits; admins are exempt.
  - Exceeding limits now returns HTTP 429 (Too Many Requests).
  - Responses include rate limit headers: RateLimit-Remaining, RateLimit-Reset, and RateLimit-Limit.

- Refactor
  - Improved role detection using role hierarchy, ensuring more accurate serialization for users and guests.

- Chores
  - Added Symfony Rate Limiter dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->